### PR TITLE
Replace Judge0 with custom code executor

### DIFF
--- a/apps/code-executor/Dockerfile
+++ b/apps/code-executor/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+# Install language runtimes
+RUN apk add --no-cache python3 py3-pip g++ openjdk17-jre
+
+# Install ts-node for TypeScript support
+RUN npm install -g ts-node typescript
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY index.js .
+
+EXPOSE 2358
+CMD ["node", "index.js"]

--- a/apps/code-executor/index.js
+++ b/apps/code-executor/index.js
@@ -1,0 +1,128 @@
+const express = require('express');
+const { spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+
+const app = express();
+app.use(express.json({ limit: '1mb' }));
+
+// Mirror Judge0 CE language IDs
+const LANGUAGES = {
+    71: { name: 'python',     cmd: ['python3'],              ext: 'py'  },
+    63: { name: 'javascript', cmd: ['node'],                 ext: 'js'  },
+    74: { name: 'typescript', cmd: ['npx', 'ts-node', '--skip-project'], ext: 'ts'  },
+    62: { name: 'java',       cmd: null,                     ext: 'java' },
+    54: { name: 'cpp',        cmd: null,                     ext: 'cpp'  },
+};
+
+const COMPILE = {
+    62: (src) => ({ compiler: 'javac', args: [src] }),
+    54: (src, out) => ({ compiler: 'g++', args: ['-o', out, src] }),
+};
+
+const TIMEOUT_MS = 10000;
+
+// Judge0-compatible submission endpoint
+app.post('/submissions', async (req, res) => {
+    const { source_code, language_id, stdin = '' } = req.body;
+
+    const lang = LANGUAGES[language_id];
+    if (!lang) {
+        return res.status(400).json({ error: `Unsupported language_id: ${language_id}` });
+    }
+
+    const id = crypto.randomUUID();
+    const tmpDir = path.join(os.tmpdir(), `exec-${id}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+
+    let srcFile = path.join(tmpDir, `solution.${lang.ext}`);
+    // Java class name must match filename
+    if (lang.name === 'java') {
+        const match = source_code.match(/public\s+class\s+(\w+)/);
+        const className = match ? match[1] : 'Solution';
+        srcFile = path.join(tmpDir, `${className}.java`);
+    }
+    fs.writeFileSync(srcFile, source_code);
+
+    try {
+        // Compile step (Java / C++)
+        if (COMPILE[language_id]) {
+            const outFile = path.join(tmpDir, 'solution');
+            const { compiler, args } = COMPILE[language_id](srcFile, outFile);
+            const compileResult = await runProcess(compiler, args, '', tmpDir);
+            if (compileResult.exitCode !== 0) {
+                return res.json({
+                    stdout: null,
+                    stderr: null,
+                    compile_output: compileResult.stderr || compileResult.stdout,
+                    status: { id: 6, description: 'Compilation Error' },
+                    time: null, memory: null, exit_code: compileResult.exitCode,
+                });
+            }
+            // Run compiled binary
+            const runCmd = lang.name === 'java'
+                ? ['java', '-cp', tmpDir, path.basename(srcFile, '.java')]
+                : [outFile];
+            const runResult = await runProcess(runCmd[0], runCmd.slice(1), stdin, tmpDir);
+            return res.json(toResponse(runResult));
+        }
+
+        // Interpreted languages
+        const [cmd, ...args] = lang.cmd;
+        const result = await runProcess(cmd, [...args, srcFile], stdin, tmpDir);
+        return res.json(toResponse(result));
+
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
+
+function runProcess(cmd, args, stdin, cwd) {
+    return new Promise((resolve) => {
+        const child = spawn(cmd, args, { cwd, env: { ...process.env, NODE_PATH: '' } });
+        let stdout = '', stderr = '';
+
+        if (stdin) child.stdin.write(stdin);
+        child.stdin.end();
+
+        child.stdout.on('data', d => { stdout += d; });
+        child.stderr.on('data', d => { stderr += d; });
+
+        const timer = setTimeout(() => {
+            child.kill('SIGKILL');
+            resolve({ stdout, stderr, exitCode: -1, timedOut: true });
+        }, TIMEOUT_MS);
+
+        child.on('close', (code) => {
+            clearTimeout(timer);
+            resolve({ stdout, stderr: stderr || null, exitCode: code ?? 0, timedOut: false });
+        });
+
+        child.on('error', (err) => {
+            clearTimeout(timer);
+            resolve({ stdout: '', stderr: err.message, exitCode: 1, timedOut: false });
+        });
+    });
+}
+
+function toResponse({ stdout, stderr, exitCode, timedOut }) {
+    if (timedOut) {
+        return { stdout: stdout || null, stderr, compile_output: null, status: { id: 5, description: 'Time Limit Exceeded' }, time: null, memory: null, exit_code: exitCode };
+    }
+    const statusId = exitCode === 0 ? 3 : 11;
+    const description = exitCode === 0 ? 'Accepted' : 'Runtime Error (NZEC)';
+    return {
+        stdout: stdout || null,
+        stderr: stderr || null,
+        compile_output: null,
+        status: { id: statusId, description },
+        time: null,
+        memory: null,
+        exit_code: exitCode,
+    };
+}
+
+const PORT = process.env.PORT || 2358;
+app.listen(PORT, () => console.log(`Code executor listening on :${PORT}`));

--- a/apps/code-executor/index.js
+++ b/apps/code-executor/index.js
@@ -81,7 +81,15 @@ app.post('/submissions', async (req, res) => {
 
 function runProcess(cmd, args, stdin, cwd) {
     return new Promise((resolve) => {
-        const child = spawn(cmd, args, { cwd, env: { ...process.env, NODE_PATH: '' } });
+        const child = spawn(cmd, args, {
+            cwd,
+            env: {
+                PATH: process.env.PATH,
+                HOME: process.env.HOME ?? '/tmp',
+                TMPDIR: process.env.TMPDIR ?? '/tmp',
+                NODE_PATH: '',
+            },
+        });
         let stdout = '', stderr = '';
 
         if (stdin) child.stdin.write(stdin);

--- a/apps/code-executor/package.json
+++ b/apps/code-executor/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "code-executor",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": { "start": "node index.js" },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/apps/collaboration-service/src/app.controller.ts
+++ b/apps/collaboration-service/src/app.controller.ts
@@ -2,7 +2,6 @@ import { Controller, Get, Post, Body, BadRequestException, InternalServerErrorEx
 import { ConfigService } from '@nestjs/config';
 import { AppService } from './app.service';
 
-// Judge0 CE language IDs
 const LANGUAGE_IDS: Record<string, number> = {
     python: 71,
     javascript: 63,
@@ -23,14 +22,6 @@ export class AppController {
         return this.appService.getHello();
     }
 
-    /**
-     * Proxies code execution to Judge0 CE (RapidAPI).
-     * Keeps the API key server-side.
-     *
-     * POST /execute
-     * Body: { language: string, code: string, stdin?: string }
-     * Returns: { stdout, stderr, compileOutput, status }
-     */
     @Post('execute')
     async execute(@Body() body: { language: string; code: string; stdin?: string }) {
         const { language, code, stdin = '' } = body;
@@ -38,16 +29,14 @@ export class AppController {
         const languageId = LANGUAGE_IDS[language];
         if (!languageId) throw new BadRequestException(`Unsupported language: ${language}`);
 
-        const judge0Url = this.configService.get<string>('JUDGE0_URL');
-        if (!judge0Url) throw new InternalServerErrorException('JUDGE0_URL is not configured');
+        const executorUrl = this.configService.get<string>('JUDGE0_URL');
+        if (!executorUrl) throw new InternalServerErrorException('JUDGE0_URL is not configured');
 
         const response = await fetch(
-            `${judge0Url}/submissions?base64_encoded=false&wait=true`,
+            `${executorUrl}/submissions?wait=true`,
             {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
+                headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     source_code: code,
                     language_id: languageId,
@@ -57,7 +46,7 @@ export class AppController {
         );
 
         if (!response.ok) {
-            throw new InternalServerErrorException(`Judge0 returned ${response.status}`);
+            throw new InternalServerErrorException(`Code executor returned ${response.status}`);
         }
 
         const data = await response.json();

--- a/apps/collaboration-service/src/app.controller.ts
+++ b/apps/collaboration-service/src/app.controller.ts
@@ -29,8 +29,8 @@ export class AppController {
         const languageId = LANGUAGE_IDS[language];
         if (!languageId) throw new BadRequestException(`Unsupported language: ${language}`);
 
-        const executorUrl = this.configService.get<string>('JUDGE0_URL');
-        if (!executorUrl) throw new InternalServerErrorException('JUDGE0_URL is not configured');
+        const executorUrl = this.configService.get<string>('CODE_EXECUTOR_URL');
+        if (!executorUrl) throw new InternalServerErrorException('CODE_EXECUTOR_URL is not configured');
 
         const response = await fetch(
             `${executorUrl}/submissions?wait=true`,

--- a/apps/collaboration-service/src/sessions/sessions.service.ts
+++ b/apps/collaboration-service/src/sessions/sessions.service.ts
@@ -21,7 +21,7 @@ export interface Session {
 }
 
 const REDIS_PREFIX = 'collab:session:';
-const FLUSH_DELAY_MS = 5000;
+const FLUSH_DELAY_MS = 1000;
 const DEFAULT_QUESTION_TIMEOUT_MS = 10000;
 const IDLE_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 

--- a/apps/frontend/src/components/collaboration/CodeSpace.tsx
+++ b/apps/frontend/src/components/collaboration/CodeSpace.tsx
@@ -71,7 +71,8 @@ function parseValue(raw: string): any {
 /**
  * Parse "nums = [-1,0,3], target = 9" → [{name:"nums", value:[-1,0,3]}, {name:"target", value:9}]
  */
-function parseInputString(input: string): ParsedVar[] {
+function parseInputString(input: unknown): ParsedVar[] {
+    if (typeof input !== 'string') return [];
     if (!input.trim()) return [];
     return splitTopLevel(input.trim()).flatMap(seg => {
         const eq = seg.indexOf('=');

--- a/apps/frontend/src/components/collaboration/CodeSpace.tsx
+++ b/apps/frontend/src/components/collaboration/CodeSpace.tsx
@@ -30,34 +30,133 @@ interface CodeSpaceProps {
 
 const STARTER_CODE = `# Write your solution here\n`;
 
-function generateStarterCode(questionId: string, testCases: TestCase[]): string {
-    const fnName = questionId.replace(/-/g, "_");
-    const firstInput = String(testCases[0]?.input ?? "");
-    const lines = firstInput.split("\n").filter(Boolean);
+// ─── Input parser ─────────────────────────────────────────────────────────────
 
-    if (lines.length === 0) return STARTER_CODE;
+interface ParsedVar { name: string; value: any; }
 
-    const params = lines.map((_, i) => `arg${i + 1}`);
-    const parseLines = lines.map((line, i) => {
-        const tokens = line.trim().split(/\s+/);
-        if (tokens.length > 1 && tokens.every(t => !isNaN(Number(t)))) {
-            return `${params[i]} = list(map(int, input().split()))`;
-        }
-        if (tokens.length === 1 && !isNaN(Number(tokens[0]))) {
-            return `${params[i]} = int(input())`;
-        }
-        return `${params[i]} = input()`;
+/** Split by top-level commas, ignoring commas inside brackets/strings. */
+function splitTopLevel(s: string): string[] {
+    const segs: string[] = [];
+    let depth = 0, start = 0, inStr = false, strChar = '';
+    for (let i = 0; i < s.length; i++) {
+        const c = s[i];
+        if (inStr) { if (c === strChar && s[i - 1] !== '\\') inStr = false; }
+        else if (c === '"' || c === "'") { inStr = true; strChar = c; }
+        else if ('[({'.includes(c)) depth++;
+        else if ('])}'.includes(c)) depth--;
+        else if (c === ',' && depth === 0) { segs.push(s.slice(start, i).trim()); start = i + 1; }
+    }
+    segs.push(s.slice(start).trim());
+    return segs.filter(Boolean);
+}
+
+/** Parse a raw value string (array, number, bool, string) into a JS value. */
+function parseValue(raw: string): any {
+    const s = raw.trim();
+    if (!s) return '';
+    try {
+        return JSON.parse(
+            s.replace(/\bTrue\b/g, 'true')
+             .replace(/\bFalse\b/g, 'false')
+             .replace(/\bNone\b/g, 'null')
+             .replace(/'/g, '"'),
+        );
+    } catch {
+        if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'")))
+            return s.slice(1, -1);
+        return s;
+    }
+}
+
+/**
+ * Parse "nums = [-1,0,3], target = 9" → [{name:"nums", value:[-1,0,3]}, {name:"target", value:9}]
+ */
+function parseInputString(input: string): ParsedVar[] {
+    if (!input.trim()) return [];
+    return splitTopLevel(input.trim()).flatMap(seg => {
+        const eq = seg.indexOf('=');
+        if (eq === -1) return [];
+        const name = seg.slice(0, eq).trim();
+        return /^\w+$/.test(name) ? [{ name, value: parseValue(seg.slice(eq + 1).trim()) }] : [];
     });
+}
 
-    return [
-        ...parseLines,
-        "",
-        `def ${fnName}(${params.join(", ")}):`,
-        "    pass",
-        "",
-        `print(${fnName}(${params.join(", ")}))`,
-        "",
-    ].join("\n");
+/** Convert a JS value to a valid Python literal. */
+function toPythonLiteral(v: any): string {
+    if (v === null || v === undefined) return 'None';
+    if (v === true) return 'True';
+    if (v === false) return 'False';
+    if (typeof v === 'string') return JSON.stringify(v);
+    if (typeof v === 'number') return String(v);
+    if (Array.isArray(v)) return `[${v.map(toPythonLiteral).join(', ')}]`;
+    if (typeof v === 'object') {
+        const pairs = Object.entries(v).map(([k, val]) => `${JSON.stringify(k)}: ${toPythonLiteral(val)}`);
+        return `{${pairs.join(', ')}}`;
+    }
+    return String(v);
+}
+
+/**
+ * Build a test harness snippet that injects parsed variables and calls the function.
+ * Returns '' for languages we can't auto-harness (Java, C++).
+ */
+function buildTestHarness(vars: ParsedVar[], fnName: string, language: string): string {
+    const args = vars.map(v => v.name).join(', ');
+    if (language === 'python') {
+        const lines = vars.map(v => `${v.name} = ${toPythonLiteral(v.value)}`);
+        return ['\n# --- test harness ---', ...lines, `_result = ${fnName}(${args})`, 'print(_result)'].join('\n');
+    }
+    if (language === 'javascript' || language === 'typescript') {
+        const lines = vars.map(v => `const ${v.name} = ${JSON.stringify(v.value)};`);
+        return ['\n// --- test harness ---', ...lines, `const _result = ${fnName}(${args});`, 'console.log(JSON.stringify(_result));'].join('\n');
+    }
+    return '';
+}
+
+/** Try to extract the first function name defined in the user's code. */
+function extractFnName(code: string, language: string): string | null {
+    if (language === 'python') return code.match(/^def\s+(\w+)\s*\(/m)?.[1] ?? null;
+    if (language === 'javascript' || language === 'typescript')
+        return code.match(/(?:^function\s+(\w+)|(?:const|let|var)\s+(\w+)\s*=\s*(?:function|\())/m)?.[1] ?? null;
+    return null;
+}
+
+/**
+ * Compare actual vs expected output, normalising whitespace and Python/JS literal differences
+ * (e.g. "[0, 1]" matches "[0,1]", "True" matches "true").
+ */
+function outputsMatch(actual: string, expected: string): boolean {
+    const a = actual.trim(), e = expected.trim();
+    if (a === e) return true;
+    const norm = (s: string) => {
+        try {
+            return JSON.stringify(JSON.parse(
+                s.replace(/\bTrue\b/g, 'true').replace(/\bFalse\b/g, 'false').replace(/\bNone\b/g, 'null').replace(/'/g, '"'),
+            ));
+        } catch { return s; }
+    };
+    return norm(a) === norm(e);
+}
+
+// ─── Starter-code generator ───────────────────────────────────────────────────
+
+function generateStarterCode(questionId: string, testCases: TestCase[], language: string): string {
+    const vars = parseInputString(testCases[0]?.input ?? '');
+    const params = vars.map(v => v.name).join(', ');
+
+    if (language === 'python') {
+        const fn = questionId.replace(/-/g, '_');
+        return `def ${fn}(${params}):\n    pass\n`;
+    }
+    if (language === 'javascript') {
+        const fn = questionId.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+        return `function ${fn}(${params}) {\n    \n}\n`;
+    }
+    if (language === 'typescript') {
+        const fn = questionId.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+        return `function ${fn}(${params}) {\n    \n}\n`;
+    }
+    return `// Write your solution here\n`;
 }
 
 
@@ -94,10 +193,10 @@ export default function CodeSpace({
     useEffect(() => {
         if (!questionId || testCases.length === 0) return;
         if (hasServerCode.current) return;
-        const generated = generateStarterCode(questionId, testCases);
+        const generated = generateStarterCode(questionId, testCases, language);
         setCode(generated);
         socket?.emit("codeUpdate", { sessionId, userId, code: generated, language });
-    }, [questionId, testCases]);
+    }, [questionId, testCases]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         if (!socket) return;
@@ -174,13 +273,26 @@ export default function CodeSpace({
             let output: RunOutput;
 
             if (testCases.length > 0) {
+                // Derive function name: prefer what the user actually defined, fall back to questionId
+                const defaultFn = questionId
+                    ? language === 'python'
+                        ? questionId.replace(/-/g, '_')
+                        : questionId.replace(/-([a-z])/g, (_, c) => c.toUpperCase())
+                    : 'solution';
+                const fnName = extractFnName(code, language) ?? defaultFn;
+
                 const results = await Promise.all(
                     testCases.map(async (tc): Promise<TestCaseResult> => {
                         try {
-                            const { stdout, stderr } = await executeCode(language, code, tc.input);
+                            const vars = parseInputString(tc.input);
+                            const harness = buildTestHarness(vars, fnName, language);
+                            // Inject harness into code; fall back to raw stdin for unsupported languages
+                            const codeToRun = harness ? code + harness : code;
+                            const stdin = harness ? '' : tc.input;
+                            const { stdout, stderr } = await executeCode(language, codeToRun, stdin);
                             const actual = stdout.trimEnd();
                             const expected = tc.expectedOutput.trimEnd();
-                            return { input: tc.input, expected, actual, passed: actual === expected, error: stderr };
+                            return { input: tc.input, expected, actual, passed: outputsMatch(actual, expected), error: stderr };
                         } catch (err: any) {
                             return { input: tc.input, expected: tc.expectedOutput, actual: "", passed: false, error: err.message };
                         }
@@ -240,7 +352,7 @@ export default function CodeSpace({
     const runLabel = isRunning ? "Running…" : peerRunning ? "Peer running…" : "▶ Run";
 
     return (
-        <div style={{ display: "flex", flexDirection: "column", gap: "10px", height: "100%", minWidth: 0 }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: "10px", height: "100%", minWidth: 0, overflow: "hidden" }}>
             {/* Header */}
             <div style={styles.header}>
                 <span style={{ fontSize: "13px", fontWeight: 600, letterSpacing: "0.02em" }}>{"</>"} Code</span>
@@ -264,7 +376,7 @@ export default function CodeSpace({
                 <button onClick={onToggle} style={styles.closeBtn} title="Hide code">×</button>
             </div>
 
-            {/* Editor + output */}
+            {/* Scrollable editor + output */}
             <div style={styles.editorWrap}>
                 <textarea
                     value={code}
@@ -275,7 +387,7 @@ export default function CodeSpace({
                     style={styles.textarea}
                 />
 
-                {/* Output panel */}
+                {/* Output panel — inside the scroll container so it's always reachable */}
                 {runOutput && (
                     <div style={styles.outputPanel}>
                         {runOutput.type === "raw" ? (
@@ -400,11 +512,12 @@ const styles: Record<string, CSSProperties> = {
     textarea: {
         flex: 1, padding: "16px", background: "transparent", border: "none",
         color: "#e6edf3", fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
-        fontSize: "13px", lineHeight: "1.7", resize: "none", outline: "none", minHeight: "180px",
+        fontSize: "13px", lineHeight: "1.7", resize: "none", outline: "none", overflowY: "auto",
     },
     outputPanel: {
+        flexShrink: 0, height: "200px", overflowY: "auto",
         borderTop: "1px solid #21262d", padding: "12px 16px",
-        background: "#161b22", maxHeight: "220px", overflow: "auto",
+        background: "#161b22",
     },
     pre: { margin: 0, fontSize: "12px", color: "#2a9d8f", whiteSpace: "pre-wrap", fontFamily: "monospace" },
     testRow: {

--- a/apps/frontend/src/components/collaboration/CodeSpace.tsx
+++ b/apps/frontend/src/components/collaboration/CodeSpace.tsx
@@ -190,13 +190,14 @@ export default function CodeSpace({
     const [partnerCursor, setPartnerCursor] = useState<{ line: number; col: number } | null>(null);
     const hasServerCode = useRef(false);
 
-    // Auto-generate boilerplate when question loads, but only if no code was saved server-side
+    // Auto-generate boilerplate when question loads, but only if no code was saved server-side.
+    // Only update local state — never emit codeUpdate here, as the socket may buffer the message
+    // and send it after connecting, overwriting the saved code on the server.
     useEffect(() => {
         if (!questionId || testCases.length === 0) return;
         if (hasServerCode.current) return;
         const generated = generateStarterCode(questionId, testCases, language);
         setCode(generated);
-        socket?.emit("codeUpdate", { sessionId, userId, code: generated, language });
     }, [questionId, testCases]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {

--- a/apps/frontend/src/pages/collaboration.tsx
+++ b/apps/frontend/src/pages/collaboration.tsx
@@ -44,6 +44,7 @@ function Collaboration() {
     const [endSessionState, setEndSessionState] = useState<"idle" | "pending" | "declined">("idle");
     const [incomingEndRequest, setIncomingEndRequest] = useState(false);
     const [partnerOnline, setPartnerOnline] = useState<boolean | null>(null);
+    const peerUsername = matchingId ? localStorage.getItem(`peer:${matchingId}`) : null;
     const whiteboardRef = useRef<WhiteboardHandle>(null);
 
     if (!matchingId || !user) return <Navigate to="/" replace />;
@@ -63,6 +64,7 @@ function Collaboration() {
                         setIsLoading(false);
                     }
                 }
+
 
                 const connectedSocket = connectSocket();
                 setSocket(connectedSocket);
@@ -198,6 +200,13 @@ function Collaboration() {
                     <span style={styles.sessionText}>{connectionState}</span>
                 </div>
 
+                {peerUsername && (
+                    <div style={styles.peerBadge}>
+                        <span style={{ fontSize: "11px", color: "#868e96" }}>Your peer:</span>
+                        <span style={{ fontSize: "12px", fontWeight: 600, color: "#f4a261" }}>{peerUsername}</span>
+                    </div>
+                )}
+
                 <VoiceCall socket={socket} sessionId={matchingId} />
 
                 <button
@@ -326,10 +335,15 @@ const COLORS: Record<string, string> = {
 };
 
 const styles: Record<string, CSSProperties> = {
-    page: { minHeight: "100vh", background: "#f5f4f2", display: "flex", flexDirection: "column" },
+    page: { height: "100vh", overflow: "hidden", background: "#f5f4f2", display: "flex", flexDirection: "column" },
     header: {
+        position: "sticky" as const, top: 0, zIndex: 100,
         marginTop: "55px", padding: "14px 28px", background: "#1a1a2e",
         display: "flex", alignItems: "center", gap: "16px", boxShadow: "0 2px 12px rgba(0,0,0,0.15)",
+    },
+    peerBadge: {
+        display: "flex", alignItems: "center", gap: "6px",
+        padding: "5px 12px", background: "#2a2a4e", borderRadius: "8px",
     },
     panelToggle: {
         marginLeft: "auto", display: "flex", background: "#2a2a4e",
@@ -352,7 +366,7 @@ const styles: Record<string, CSSProperties> = {
     sessionText: { color: "#a9b1d6", fontSize: "12px", textTransform: "capitalize" },
     layoutGrid: {
         flex: 1, display: "grid", gridTemplateColumns: "340px 1fr",
-        gap: "0", minHeight: 0, height: "calc(100vh - 60px)",
+        gap: "0", minHeight: 0, overflow: "hidden",
     },
     questionColumn: {
         padding: "20px 16px", background: "#fff", borderRight: "1px solid #e9ecef",
@@ -372,8 +386,8 @@ const styles: Record<string, CSSProperties> = {
     constraintsList: { margin: 0, paddingLeft: "16px", lineHeight: "1.8" },
     constraint: { fontFamily: "monospace" },
     rightColumn: { padding: "20px", display: "flex", gap: "16px", overflow: "hidden", height: "100%" },
-    whiteboard: { minWidth: 0, height: 1000, transition: "flex 0.3s ease", display: "flex", flexDirection: "column" },
-    codeSpace: { minWidth: 0, transition: "flex 0.3s ease", display: "flex", flexDirection: "column" },
+    whiteboard: { minWidth: 0, minHeight: 0, overflow: "hidden", transition: "flex 0.3s ease", display: "flex", flexDirection: "column" },
+    codeSpace: { minWidth: 0, minHeight: 0, overflow: "hidden", transition: "flex 0.3s ease", display: "flex", flexDirection: "column" },
     partnerDisconnectedBanner: {
         display: "flex", alignItems: "center", gap: "12px", padding: "10px 28px",
         background: "#2a2a4e", color: "#f4a261", borderBottom: "1px solid #f4a261",

--- a/apps/frontend/src/pages/homepage.tsx
+++ b/apps/frontend/src/pages/homepage.tsx
@@ -167,6 +167,9 @@ function Homepage() {
         isMatchedRef.current = true;
         stopAll();
         setMatchStatus("Match found! Redirecting...");
+        if (data.matchedWith?.username) {
+            localStorage.setItem(`peer:${data.roomId}`, data.matchedWith.username);
+        }
         setTimeout(() => {
             setIsMatchmaking(false);
             navigate(`/collaboration/${data.roomId}`);

--- a/compose.yml
+++ b/compose.yml
@@ -144,6 +144,11 @@ services:
       - "2358:2358"
     mem_limit: 512m
     cpus: "1.0"
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:2358/', r => process.exit(r.statusCode < 500 ? 0 : 1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     networks:
       - peerprep-network
 

--- a/compose.yml
+++ b/compose.yml
@@ -142,6 +142,8 @@ services:
     restart: unless-stopped
     ports:
       - "2358:2358"
+    mem_limit: 512m
+    cpus: "1.0"
     networks:
       - peerprep-network
 

--- a/compose.yml
+++ b/compose.yml
@@ -124,7 +124,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       QUESTION_SERVICE_URL: http://question-service:3002
       USER_SERVICE_URL: http://user-service:3001
-      JUDGE0_URL: http://judge0-server:2358
+      JUDGE0_URL: http://code-executor:2358
     depends_on:
       redis:
         condition: service_healthy
@@ -132,64 +132,16 @@ services:
       - peerprep-network
 
   # ============================================
-  # Judge0 (Code Execution) — Port 2358
+  # Code Executor (custom, ARM64-native) — Port 2358
   # ============================================
-  judge0-server:
-    image: judge0/judge0:1.13.1
-    volumes:
-      - ./infra/docker/judge0.conf:/judge0.conf:ro
+  code-executor:
+    build:
+      context: ./apps/code-executor
+      dockerfile: Dockerfile
+    container_name: peerprep-code-executor
+    restart: unless-stopped
     ports:
       - "2358:2358"
-    privileged: true
-    restart: always
-    environment:
-      REDIS_URL: redis://judge0-redis:6379
-      REDIS_HOST: judge0-redis
-      REDIS_PORT: 6379
-      POSTGRES_HOST: judge0-db
-      POSTGRES_DB: ${JUDGE0_POSTGRES_DB}
-      POSTGRES_USER: ${JUDGE0_POSTGRES_USER}
-      POSTGRES_PASSWORD: ${JUDGE0_POSTGRES_PASSWORD}
-    depends_on:
-      - judge0-db
-      - judge0-redis
-    networks:
-      - peerprep-network
-
-  judge0-workers:
-    image: judge0/judge0:1.13.1
-    command: ["./scripts/workers"]
-    volumes:
-      - ./infra/docker/judge0.conf:/judge0.conf:ro
-    privileged: true
-    restart: always
-    environment:
-      REDIS_URL: redis://judge0-redis:6379
-      REDIS_HOST: judge0-redis
-      REDIS_PORT: 6379
-      POSTGRES_HOST: judge0-db
-      POSTGRES_DB: ${JUDGE0_POSTGRES_DB}
-      POSTGRES_USER: ${JUDGE0_POSTGRES_USER}
-      POSTGRES_PASSWORD: ${JUDGE0_POSTGRES_PASSWORD}
-    depends_on:
-      - judge0-db
-      - judge0-redis
-    networks:
-      - peerprep-network
-
-  judge0-db:
-    image: postgres:13
-    environment:
-      POSTGRES_DB: ${JUDGE0_POSTGRES_DB}
-      POSTGRES_USER: ${JUDGE0_POSTGRES_USER}
-      POSTGRES_PASSWORD: ${JUDGE0_POSTGRES_PASSWORD}
-    volumes:
-      - judge0-db-data:/var/lib/postgresql/data
-    networks:
-      - peerprep-network
-
-  judge0-redis:
-    image: redis:6.0
     networks:
       - peerprep-network
 
@@ -233,7 +185,6 @@ services:
 volumes:
   mongodb_data:
   redis_data:
-  judge0-db-data:
 
 networks:
   peerprep-network:

--- a/compose.yml
+++ b/compose.yml
@@ -124,7 +124,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       QUESTION_SERVICE_URL: http://question-service:3002
       USER_SERVICE_URL: http://user-service:3001
-      JUDGE0_URL: http://code-executor:2358
+      CODE_EXECUTOR_URL: http://code-executor:2358
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- **New `code-executor` service**: Replaces Judge0 CE with a lightweight custom Express service (`apps/code-executor/`) supporting Python, JavaScript, TypeScript, Java, and C++. Removes the Judge0 server, workers, Postgres, and Redis dependencies from `compose.yml`, reducing infrastructure complexity and fixing ARM64 compatibility issues.
- **Collaboration service**: Updated `/execute` proxy to point at the new `code-executor` container (same Judge0-compatible API shape, `JUDGE0_URL` env var reused). Reduced Redis session flush delay from 5000ms → 1000ms so code edits persist faster.
- **CodeSpace (frontend)**: Rewrote test case runner with a proper input parser and per-language test harness builder that injects parsed variables and calls the user's function directly. Added output normalisation so `[0, 1]` matches `[0,1]`, `True` matches `true`, etc. Starter code generation now produces correct function signatures for Python/JS/TS based on the question's test case variable names. Fixed a bug where starter code was emitted as a `codeUpdate` before the socket connected, causing buffered messages to overwrite saved code on refresh.
- **Collaboration page**: Display peer's username in the header (stored in localStorage on match). Layout fixes — `overflow: hidden` on page/grid to prevent scroll bleed, sticky header, fixed output panel height.
- **Homepage**: Store matched peer's username in localStorage keyed by room ID so it's available in the collaboration page.

## Update

- Fix JUDGE0 naming occurrences to CODE_EXECUTOR
- Set memory limit of code-executor service
- Pass only required fields from process.env
- Create health check for code-executor
