### PR TITLE
Create test cases for Collaboration Service

### DIFF
--- a/apps/collaboration-service/package.json
+++ b/apps/collaboration-service/package.json
@@ -63,7 +63,10 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "roots": [
+      "<rootDir>/src",
+      "<rootDir>/test"
+    ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/apps/collaboration-service/src/app.controller.spec.ts
+++ b/apps/collaboration-service/src/app.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { ConfigService } from '@nestjs/config';
 
 describe('AppController', () => {
   let appController: AppController;
@@ -8,7 +9,13 @@ describe('AppController', () => {
   beforeEach(async () => {
     const app: TestingModule = await Test.createTestingModule({
       controllers: [AppController],
-      providers: [AppService],
+      providers: [
+        AppService,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn() },
+        },
+      ],
     }).compile();
 
     appController = app.get<AppController>(AppController);

--- a/apps/collaboration-service/src/sessions/sessions.controller.ts
+++ b/apps/collaboration-service/src/sessions/sessions.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Body, Param, NotFoundException, UseGuards, ForbiddenException, Req } from '@nestjs/common';
+import { Controller, Post, Get, Param, NotFoundException, UseGuards, ForbiddenException, Req } from '@nestjs/common';
 import { Request } from 'express';
 import { SessionsService } from './sessions.service';
 import { UserGuard } from '../auth/user.guard';
@@ -10,18 +10,6 @@ type AuthenticatedRequest = Request & {
 @Controller('sessions')
 export class SessionsController {
     constructor(private readonly sessionsService: SessionsService) {}
-
-    @Post('create')
-    async create(@Body() body: {
-        userAId: string;
-        userBId: string;
-        matchId: string;
-        topic: string;
-        userADifficulty: string;
-        userBDifficulty: string;
-    }) {
-        return this.sessionsService.create(body);
-    }
 
     @UseGuards(UserGuard)
     @Get(':id')

--- a/apps/collaboration-service/src/sessions/sessions.service.ts
+++ b/apps/collaboration-service/src/sessions/sessions.service.ts
@@ -166,11 +166,10 @@ export class SessionsService implements OnModuleInit, OnModuleDestroy {
     }
 
     /**
-     * Called by Question Service once it has selected a question for this session.
-     * Sets session status to 'active' and pushes 'questionReady' to both users.
-     *
-     * POST /sessions/:id/question
-     * Body: { question: Question }
+     * Attaches a question to the session and transitions status to 'active'.
+     * Called internally by fetchAndAttachQuestion (on success) and the
+     * question timeout fallback (getMockQuestion). Emits 'questionReady' to
+     * both users via the socket room.
      */
     async attachQuestion(sessionId: string, question: any): Promise<void> {
         const session = this.sessions.get(sessionId);

--- a/apps/collaboration-service/src/sessions/sessions.service.ts
+++ b/apps/collaboration-service/src/sessions/sessions.service.ts
@@ -407,9 +407,15 @@ export class SessionsService implements OnModuleInit, OnModuleDestroy {
         const room = io.sockets.adapter.rooms.get(sessionId);
         const remaining = room ? room.size : 0;
 
-        if (remaining > 0) return; // partner is still connected
+        // Start idle timer whenever at least one user has left (remaining < 2).
+        // This covers both: one user leaves while the other stays, and both leave.
+        // We emit endSession:confirmed to whoever is still in the room (may be nobody).
+        if (remaining >= 2) return;
 
-        this.logger.log(`All users left session ${sessionId} — starting ${IDLE_TIMEOUT_MS / 1000}s idle timer`);
+        // Don't double-start if a timer is already running
+        if (this.idleTimers.has(sessionId)) return;
+
+        this.logger.log(`User left session ${sessionId} (${remaining} remaining) — starting ${IDLE_TIMEOUT_MS / 1000}s idle timer`);
         const timer = setTimeout(async () => {
             this.idleTimers.delete(sessionId);
             this.logger.log(`Idle timeout reached — auto-terminating session ${sessionId}`);

--- a/apps/collaboration-service/src/whiteboard/whiteboard.gateway.ts
+++ b/apps/collaboration-service/src/whiteboard/whiteboard.gateway.ts
@@ -57,7 +57,14 @@ export class WhiteboardGateway implements OnGatewayInit, OnGatewayConnection, On
     }
 
     handleDisconnect(client: Socket) {
-        const { sessionId, userId } = client.data ?? {};
+        // client.data.sessionId is set in handleJoinSession. If the socket
+        // disconnects before joinSession fires (e.g. on a fast refresh),
+        // fall back to the rooms the socket was in.
+        const sessionId: string | undefined =
+            client.data?.sessionId ??
+            [...client.rooms].find(r => r !== client.id);
+        const userId: string | undefined = client.data?.userId;
+
         console.log(`Client disconnected: ${client.id}${sessionId ? ` (session ${sessionId})` : ''}`);
         if (sessionId) {
             client.to(sessionId).emit('partnerDisconnected', { userId });

--- a/apps/collaboration-service/test/sessions.controller.spec.ts
+++ b/apps/collaboration-service/test/sessions.controller.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { SessionsController } from '../src/sessions/sessions.controller';
 import { SessionsService } from '../src/sessions/sessions.service';
@@ -38,7 +38,6 @@ describe('SessionsController', () => {
 
     beforeEach(async () => {
         const mockService: Partial<jest.Mocked<SessionsService>> = {
-            create: jest.fn(),
             findOne: jest.fn(),
             endSession: jest.fn(),
         };
@@ -66,30 +65,6 @@ describe('SessionsController', () => {
 
     afterEach(async () => {
         await app.close();
-    });
-
-    // ─── POST /sessions/create ─────────────────────────────────────────────────
-
-    describe('POST /sessions/create', () => {
-        it('creates a session and returns it', async () => {
-            const session = makeSession();
-            sessionsService.create.mockResolvedValue(session);
-
-            const res = await request(app.getHttpServer())
-                .post('/sessions/create')
-                .send({
-                    userAId: 'user-a',
-                    userBId: 'user-b',
-                    matchId: 'session-1',
-                    topic: 'Arrays',
-                    userADifficulty: 'Easy',
-                    userBDifficulty: 'Medium',
-                })
-                .expect(201);
-
-            expect(res.body.sessionId).toBe('session-1');
-            expect(res.body.status).toBe('active');
-        });
     });
 
     // ─── GET /sessions/:id ─────────────────────────────────────────────────────

--- a/apps/collaboration-service/test/sessions.controller.spec.ts
+++ b/apps/collaboration-service/test/sessions.controller.spec.ts
@@ -1,0 +1,198 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, NotFoundException, ForbiddenException } from '@nestjs/common';
+import request from 'supertest';
+import { SessionsController } from '../src/sessions/sessions.controller';
+import { SessionsService } from '../src/sessions/sessions.service';
+import { UserGuard } from '../src/auth/user.guard';
+import { Session } from '../src/sessions/sessions.service';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+    return {
+        sessionId: 'session-1',
+        userAId: 'user-a',
+        userBId: 'user-b',
+        matchId: 'session-1',
+        topic: 'Arrays',
+        question: { questionId: 'two-sum', title: 'Two Sum' },
+        whiteboardElements: [],
+        code: 'print(1)',
+        language: 'python',
+        revealedHints: 0,
+        testCasesPassed: 2,
+        status: 'active',
+        createdAt: new Date(),
+        ...overrides,
+    };
+}
+
+// Bypass JWT guard for controller unit tests
+const mockUserGuard = { canActivate: jest.fn().mockReturnValue(true) };
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('SessionsController', () => {
+    let app: INestApplication;
+    let sessionsService: jest.Mocked<SessionsService>;
+
+    beforeEach(async () => {
+        const mockService: Partial<jest.Mocked<SessionsService>> = {
+            create: jest.fn(),
+            findOne: jest.fn(),
+            endSession: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [SessionsController],
+            providers: [
+                { provide: SessionsService, useValue: mockService },
+            ],
+        })
+            .overrideGuard(UserGuard)
+            .useValue(mockUserGuard)
+            .compile();
+
+        app = module.createNestApplication();
+        // Attach a mock user to every request (simulates a valid JWT)
+        app.use((req: any, _res: any, next: any) => {
+            req.user = { id: 'user-a', isAdmin: false };
+            next();
+        });
+        await app.init();
+
+        sessionsService = module.get(SessionsService);
+    });
+
+    afterEach(async () => {
+        await app.close();
+    });
+
+    // ─── POST /sessions/create ─────────────────────────────────────────────────
+
+    describe('POST /sessions/create', () => {
+        it('creates a session and returns it', async () => {
+            const session = makeSession();
+            sessionsService.create.mockResolvedValue(session);
+
+            const res = await request(app.getHttpServer())
+                .post('/sessions/create')
+                .send({
+                    userAId: 'user-a',
+                    userBId: 'user-b',
+                    matchId: 'session-1',
+                    topic: 'Arrays',
+                    userADifficulty: 'Easy',
+                    userBDifficulty: 'Medium',
+                })
+                .expect(201);
+
+            expect(res.body.sessionId).toBe('session-1');
+            expect(res.body.status).toBe('active');
+        });
+    });
+
+    // ─── GET /sessions/:id ─────────────────────────────────────────────────────
+
+    describe('GET /sessions/:id', () => {
+        it('returns the session for an authorised user', async () => {
+            sessionsService.findOne.mockReturnValue(makeSession());
+
+            const res = await request(app.getHttpServer())
+                .get('/sessions/session-1')
+                .expect(200);
+
+            expect(res.body.sessionId).toBe('session-1');
+            expect(res.body.code).toBe('print(1)');
+        });
+
+        it('returns 404 when session does not exist', async () => {
+            sessionsService.findOne.mockReturnValue(undefined);
+
+            await request(app.getHttpServer())
+                .get('/sessions/no-such-session')
+                .expect(404);
+        });
+
+        it('returns 403 when user is not part of the session', async () => {
+            // session belongs to user-a and user-b, but request user is user-c
+            sessionsService.findOne.mockReturnValue(
+                makeSession({ userAId: 'user-x', userBId: 'user-y' }),
+            );
+
+            // Override the middleware user for this test
+            const moduleRef = await Test.createTestingModule({
+                controllers: [SessionsController],
+                providers: [{ provide: SessionsService, useValue: sessionsService }],
+            })
+                .overrideGuard(UserGuard)
+                .useValue(mockUserGuard)
+                .compile();
+
+            const altApp = moduleRef.createNestApplication();
+            altApp.use((req: any, _res: any, next: any) => {
+                req.user = { id: 'user-c', isAdmin: false };
+                next();
+            });
+            await altApp.init();
+
+            await request(altApp.getHttpServer())
+                .get('/sessions/session-1')
+                .expect(403);
+
+            await altApp.close();
+        });
+    });
+
+    // ─── POST /sessions/:id/end ────────────────────────────────────────────────
+
+    describe('POST /sessions/:id/end', () => {
+        it('ends the session and returns a redirect URL', async () => {
+            sessionsService.findOne.mockReturnValue(makeSession());
+            sessionsService.endSession.mockResolvedValue(makeSession({ status: 'ended' }));
+
+            const res = await request(app.getHttpServer())
+                .post('/sessions/session-1/end')
+                .expect(201);
+
+            expect(res.body.message).toBe('Session ended');
+            expect(res.body.redirectUrl).toBe('/homepage');
+            expect(sessionsService.endSession).toHaveBeenCalledWith('session-1');
+        });
+
+        it('returns 404 when session does not exist', async () => {
+            sessionsService.findOne.mockReturnValue(undefined);
+
+            await request(app.getHttpServer())
+                .post('/sessions/no-such-session/end')
+                .expect(404);
+        });
+
+        it('returns 403 when user is not part of the session', async () => {
+            sessionsService.findOne.mockReturnValue(
+                makeSession({ userAId: 'user-x', userBId: 'user-y' }),
+            );
+
+            const moduleRef = await Test.createTestingModule({
+                controllers: [SessionsController],
+                providers: [{ provide: SessionsService, useValue: sessionsService }],
+            })
+                .overrideGuard(UserGuard)
+                .useValue(mockUserGuard)
+                .compile();
+
+            const altApp = moduleRef.createNestApplication();
+            altApp.use((req: any, _res: any, next: any) => {
+                req.user = { id: 'user-c', isAdmin: false };
+                next();
+            });
+            await altApp.init();
+
+            await request(altApp.getHttpServer())
+                .post('/sessions/session-1/end')
+                .expect(403);
+
+            await altApp.close();
+        });
+    });
+});

--- a/apps/collaboration-service/test/sessions.service.spec.ts
+++ b/apps/collaboration-service/test/sessions.service.spec.ts
@@ -1,0 +1,291 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { SessionsService } from '../src/sessions/sessions.service';
+
+// ─── Redis mock ───────────────────────────────────────────────────────────────
+
+const redisMock = {
+    connect: jest.fn().mockResolvedValue(undefined),
+    disconnect: jest.fn(),
+    set: jest.fn().mockResolvedValue('OK'),
+    get: jest.fn().mockResolvedValue(null),
+    del: jest.fn().mockResolvedValue(1),
+    keys: jest.fn().mockResolvedValue([]),
+    xadd: jest.fn().mockResolvedValue('stream-id'),
+    on: jest.fn(),
+};
+
+jest.mock('ioredis', () => {
+    return jest.fn().mockImplementation(() => redisMock);
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeSessionData(overrides: Partial<{
+    userAId: string;
+    userBId: string;
+    matchId: string;
+    topic: string;
+    userADifficulty: string | null;
+    userBDifficulty: string | null;
+}> = {}) {
+    return {
+        userAId: 'user-a',
+        userBId: 'user-b',
+        matchId: 'match-123',
+        topic: 'Arrays',
+        userADifficulty: null,
+        userBDifficulty: null,
+        ...overrides,
+    };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('SessionsService', () => {
+    let service: SessionsService;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                SessionsService,
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn((key: string) => {
+                            const config: Record<string, string | number> = {
+                                REDIS_URL: 'redis://localhost:6379',
+                                JWT_SECRET: 'test-secret',
+                                QUESTION_TIMEOUT_MS: 99999, // prevent fallback from firing during tests
+                            };
+                            return config[key];
+                        }),
+                    },
+                },
+            ],
+        }).compile();
+
+        service = module.get<SessionsService>(SessionsService);
+        // Skip Redis connection in tests
+        await service.onModuleInit();
+    });
+
+    afterEach(async () => {
+        await service.onModuleDestroy();
+    });
+
+    // ─── create ───────────────────────────────────────────────────────────────
+
+    describe('create', () => {
+        it('creates a session with waiting status and default fields', async () => {
+            const data = makeSessionData();
+            const session = await service.create(data);
+
+            expect(session.sessionId).toBe('match-123');
+            expect(session.userAId).toBe('user-a');
+            expect(session.userBId).toBe('user-b');
+            expect(session.status).toBe('waiting');
+            expect(session.code).toBe('');
+            expect(session.language).toBe('python');
+            expect(session.revealedHints).toBe(0);
+            expect(session.testCasesPassed).toBe(0);
+            expect(session.question).toBeNull();
+            expect(session.whiteboardElements).toEqual([]);
+        });
+
+        it('persists session to Redis immediately on creation', async () => {
+            await service.create(makeSessionData());
+            expect(redisMock.set).toHaveBeenCalledWith(
+                'collab:session:match-123',
+                expect.stringContaining('"sessionId":"match-123"'),
+            );
+        });
+
+        it('makes the session findable after creation', async () => {
+            await service.create(makeSessionData());
+            const found = service.findOne('match-123');
+            expect(found).toBeDefined();
+            expect(found?.sessionId).toBe('match-123');
+        });
+
+        it('returns undefined for a non-existent session', () => {
+            const found = service.findOne('does-not-exist');
+            expect(found).toBeUndefined();
+        });
+    });
+
+    // ─── attachQuestion ───────────────────────────────────────────────────────
+
+    describe('attachQuestion', () => {
+        const mockQuestion = {
+            questionId: 'two-sum',
+            title: 'Two Sum',
+            topic: ['Arrays'],
+            difficulty: 'Easy',
+        };
+
+        it('sets question and transitions status to active', async () => {
+            await service.create(makeSessionData());
+            await service.attachQuestion('match-123', mockQuestion);
+
+            const session = service.findOne('match-123');
+            expect(session?.question).toEqual(mockQuestion);
+            expect(session?.status).toBe('active');
+        });
+
+        it('flushes to Redis after attaching a question', async () => {
+            await service.create(makeSessionData());
+            redisMock.set.mockClear();
+
+            await service.attachQuestion('match-123', mockQuestion);
+            expect(redisMock.set).toHaveBeenCalledWith(
+                'collab:session:match-123',
+                expect.stringContaining('"status":"active"'),
+            );
+        });
+
+        it('throws if session does not exist', async () => {
+            await expect(
+                service.attachQuestion('no-such-session', mockQuestion),
+            ).rejects.toThrow('Session not found: no-such-session');
+        });
+    });
+
+    // ─── updateCode ───────────────────────────────────────────────────────────
+
+    describe('updateCode', () => {
+        it('updates code on the session', async () => {
+            await service.create(makeSessionData());
+            service.updateCode('match-123', 'print("hello")', 'python');
+
+            const session = service.findOne('match-123');
+            expect(session?.code).toBe('print("hello")');
+            expect(session?.language).toBe('python');
+        });
+
+        it('updates language when provided', async () => {
+            await service.create(makeSessionData());
+            service.updateCode('match-123', 'console.log(1)', 'javascript');
+
+            expect(service.findOne('match-123')?.language).toBe('javascript');
+        });
+
+        it('does not change language when not provided', async () => {
+            await service.create(makeSessionData());
+            service.updateCode('match-123', 'some code');
+
+            expect(service.findOne('match-123')?.language).toBe('python');
+        });
+
+        it('does nothing for a non-existent session', () => {
+            expect(() => service.updateCode('ghost', 'code')).not.toThrow();
+        });
+    });
+
+    // ─── updateRevealedHints ──────────────────────────────────────────────────
+
+    describe('updateRevealedHints', () => {
+        it('updates the revealed hints count', async () => {
+            await service.create(makeSessionData());
+            service.updateRevealedHints('match-123', 2);
+
+            expect(service.findOne('match-123')?.revealedHints).toBe(2);
+        });
+
+        it('does nothing for a non-existent session', () => {
+            expect(() => service.updateRevealedHints('ghost', 1)).not.toThrow();
+        });
+    });
+
+    // ─── updateTestCasesPassed ────────────────────────────────────────────────
+
+    describe('updateTestCasesPassed', () => {
+        it('updates the test cases passed count', async () => {
+            await service.create(makeSessionData());
+            service.updateTestCasesPassed('match-123', 3);
+
+            expect(service.findOne('match-123')?.testCasesPassed).toBe(3);
+        });
+
+        it('does nothing for a non-existent session', () => {
+            expect(() => service.updateTestCasesPassed('ghost', 1)).not.toThrow();
+        });
+    });
+
+    // ─── updateWhiteboard ─────────────────────────────────────────────────────
+
+    describe('updateWhiteboard', () => {
+        it('updates whiteboard elements', async () => {
+            await service.create(makeSessionData());
+            const elements = [{ type: 'rect', x: 0, y: 0 }];
+            service.updateWhiteboard('match-123', elements);
+
+            expect(service.findOne('match-123')?.whiteboardElements).toEqual(elements);
+        });
+
+        it('does nothing for a non-existent session', () => {
+            expect(() => service.updateWhiteboard('ghost', [])).not.toThrow();
+        });
+    });
+
+    // ─── endSession ───────────────────────────────────────────────────────────
+
+    describe('endSession', () => {
+        it('marks session as ended and removes it from memory', async () => {
+            await service.create(makeSessionData());
+            await service.endSession('match-123');
+
+            expect(service.findOne('match-123')).toBeUndefined();
+        });
+
+        it('deletes the Redis key when session ends', async () => {
+            await service.create(makeSessionData());
+            await service.endSession('match-123');
+
+            expect(redisMock.del).toHaveBeenCalledWith('collab:session:match-123');
+        });
+
+        it('publishes session.completed event to Redis stream', async () => {
+            await service.create(makeSessionData());
+            await service.attachQuestion('match-123', {
+                questionId: 'two-sum', title: 'Two Sum', topic: ['Arrays'], difficulty: 'Easy',
+            });
+            service.updateCode('match-123', 'print(1)', 'python');
+
+            await service.endSession('match-123');
+
+            expect(redisMock.xadd).toHaveBeenCalledWith(
+                'session.completed', '*',
+                expect.anything(), expect.anything(), // sessionId
+                expect.anything(), expect.anything(), // userAId
+                expect.anything(), expect.anything(), // userBId
+                expect.anything(), expect.anything(), // questionId
+                expect.anything(), expect.anything(), // questionTitle
+                expect.anything(), expect.anything(), // topic
+                expect.anything(), expect.anything(), // difficulty
+                'code', 'print(1)',
+                'language', 'python',
+                expect.anything(), expect.anything(), // hintsUsed
+                expect.anything(), expect.anything(), // testCasesPassed
+                expect.anything(), expect.anything(), // duration
+                expect.anything(), expect.anything(), // whiteboardScreenshot
+            );
+        });
+
+        it('returns undefined for a non-existent session', async () => {
+            const result = await service.endSession('no-such-session');
+            expect(result).toBeUndefined();
+        });
+    });
+
+    // ─── onUserJoined / onUserLeft ────────────────────────────────────────────
+
+    describe('onUserJoined', () => {
+        it('does not throw when called for a session with no idle timer', async () => {
+            await service.create(makeSessionData());
+            expect(() => service.onUserJoined('match-123')).not.toThrow();
+        });
+    });
+});

--- a/apps/frontend/src/pages/collaboration.tsx
+++ b/apps/frontend/src/pages/collaboration.tsx
@@ -44,7 +44,35 @@ function Collaboration() {
     const [endSessionState, setEndSessionState] = useState<"idle" | "pending" | "declined">("idle");
     const [incomingEndRequest, setIncomingEndRequest] = useState(false);
     const [partnerOnline, setPartnerOnline] = useState<boolean | null>(null);
+    const [disconnectCountdown, setDisconnectCountdown] = useState<number | null>(null);
+    const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
     const whiteboardRef = useRef<WhiteboardHandle>(null);
+
+    // Start a 120s countdown when partner disconnects, clear it when they rejoin
+    useEffect(() => {
+        if (partnerOnline === false) {
+            setDisconnectCountdown(120);
+            countdownRef.current = setInterval(() => {
+                setDisconnectCountdown(prev => {
+                    if (prev === null || prev <= 1) {
+                        clearInterval(countdownRef.current!);
+                        countdownRef.current = null;
+                        return null;
+                    }
+                    return prev - 1;
+                });
+            }, 1000);
+        } else {
+            if (countdownRef.current) {
+                clearInterval(countdownRef.current);
+                countdownRef.current = null;
+            }
+            setDisconnectCountdown(null);
+        }
+        return () => {
+            if (countdownRef.current) clearInterval(countdownRef.current);
+        };
+    }, [partnerOnline]);
 
     if (!matchingId || !user) return <Navigate to="/" replace />;
 
@@ -217,7 +245,10 @@ function Collaboration() {
             {partnerOnline === false && (
                 <div style={styles.partnerDisconnectedBanner}>
                     <span style={{ fontSize: "14px" }}>
-                        ⚠️ Your partner has disconnected. Session will auto-close if they don't rejoin within 2 minutes.
+                        ⚠️ Your partner has disconnected.
+                        {disconnectCountdown !== null && (
+                            <> Session will auto-close in <strong>{Math.floor(disconnectCountdown / 60)}:{String(disconnectCountdown % 60).padStart(2, "0")}</strong>.</>
+                        )}
                     </span>
                 </div>
             )}


### PR DESCRIPTION
Created unit tests for Collab Service, split across two files:

`test/sessions.service.spec.ts`  tests business logic:
Tests `SessionsService` in isolation with Redis fully mocked out. Covers the core session lifecycle:
- Creating a session sets the right defaults and persists to Redis
- Attaching a question transitions the session from waiting to active
- Updating code, language, hints, test cases passed, and whiteboard elements all mutate state correctly
- Ending a session removes it from memory, cleans up Redis, and publishes a completion event to the Redis stream
- Edge cases like calling update/end on non-existent sessions don't throw

`test/sessions.controller.spec.ts` tests the HTTP layer
Tests `SessionsController` with `SessionsService` mocked and the JWT guard bypassed. Covers the three REST endpoints:
- `GET /sessions/:id` returns the session for an authorised user, 404 for missing, 403 if the requesting user isn't part of the session
- `POST /sessions/:id/end` returns a redirect URL, 404 for missing, 403 for wrong user

Others:
- Removed code not required e.g. end points not used
- Fix user not being kicked out after 2 minutes countdown